### PR TITLE
Add Elasticache Benchmark Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,29 @@ Create a stack based on `global-wrapper.yaml` if you want to run your network be
 
 ## ElastiCache
 _See scripts `benchmark-cache.{family}.sh`_
+
+### Querying Results
+#### Highest Bandwidth Test Configurations
+If you have run tests with various data sizes (`RedisDataSize` parameter in
+[benchmark-elasticache-redis.yaml](benchmark-elasticache-redis.yaml)), the
+following query will show you under which size data you'll get what level
+of bandwidth performance from. Ideally, you should profile what your data
+sizes are in your target environment, and what traffic level they tend to
+receive, and pick one-or-more data size parameters to exercise.
+
+```sql
+SELECT
+    instancetype,
+    dataSize,
+    (avg(networkbytesout.p90)/60/1024/1024*8) AS mbps_p90,
+    (avg(networkbytesout.p70)/60/1024/1024*8) AS mbps_p70,
+    count(distinct benchmarkId) as test_passes,
+    avg(cpuutilization.p90) AS cpuutilization_90,
+    avg(enginecpuutilization.p90) AS enginecpuutilization_90,
+    avg(cpuutilization.p50) AS cpuutilization_50,
+    avg(enginecpuutilization.p50) AS enginecpuutilization_50
+FROM cachenetworkbenchmark
+WHERE d >= from_iso8601_date('2018-05-01')
+GROUP BY region, instancetype, dataSize
+ORDER BY mbps_p90 DESC, region, instancetype, dataSize
+```

--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ All you need to run your own Network Benchmarks on EC2.
 1. Create a stack based on `benchmark.yaml` to run a network benchmark or use one of the `benchmark-*.sh` scripts to do so.
 
 Create a stack based on `global-wrapper.yaml` if you want to run your network benchmark in multiple regions. Requires a stack based on `global.yaml` within another region.
+
+- - -
+
+# ec2-network-benchmark
+
+## ElastiCache
+_See scripts `benchmark-cache.{family}.sh`_

--- a/README.md
+++ b/README.md
@@ -42,3 +42,13 @@ WHERE d >= from_iso8601_date('2018-05-01')
 GROUP BY region, instancetype, dataSize
 ORDER BY mbps_p90 DESC, region, instancetype, dataSize
 ```
+
+**Example Results:**
+
+| instancetype | dataSize | mbps_p90 | mbps_p70 | test_passes | cpuutilization_90 | enginecpuutilization_90 | cpuutilization_50 | enginecpuutilization_50 |
+| ------------ | -------- | -------- | -------- | ----------- | ----------------- | ----------------------- | ----------------- | ----------------------- |
+| `cache.r4.4xlarge`  | 100000 | 9211.309 | 9098.941  | 3 | 9.273073  | 49.221848 | 6.251554  | 46.502052 |
+| `cache.r4.8xlarge`  | 100000 | 9106.479 | 8965.279  | 3 | 5.1063986 | 49.136944 | 4.6466618 | 40.50802  |
+| `cache.m4.10xlarge` | 100000 | 8990.691 | 8957.348  | 2 | 2.3085928 | 39.05509  | 2.2267942 | 30.193382 |
+| `cache.r4.2xlarge`  | 100000 | 7828.376 | 7587.0874 | 3 | 32.194942 | 59.450256 | 26.06959  | 50.664406 |
+| `cache.r4.xlarge`   | 100000 | 6234.919 | 6155.1865 | 2 | 55.188168 | 61.926918 | 37.938736 | 59.221046 |

--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@ _See scripts `benchmark-cache.{family}.sh`_
 
 ### Querying Results
 #### Highest Bandwidth Test Configurations
-If you have run tests with various data sizes (`RedisDataSize` parameter in
+If you have run tests with various data sizes (`RedisDataSizes` parameter in
 [benchmark-elasticache-redis.yaml](benchmark-elasticache-redis.yaml)), the
 following query will show you under which size data you'll get what level
 of bandwidth performance from. Ideally, you should profile what your data
 sizes are in your target environment, and what traffic level they tend to
 receive, and pick one-or-more data size parameters to exercise.
+
+_Note: Keep in mind the creation time limit is 75 minutes. Depending on the
+test duration being used and number of data sizes, it's possible to have your
+tests never complete._
 
 ```sql
 SELECT

--- a/athena-cache.sql
+++ b/athena-cache.sql
@@ -1,0 +1,41 @@
+
+# Delete existing table
+
+DROP TABLE IF EXISTS cachenetworkbenchmark;
+
+# Create table
+
+CREATE EXTERNAL TABLE IF NOT EXISTS cachenetworkbenchmark (
+  benchmarkId string,
+  dataSize int,
+  instanceType string,
+  instanceTypeClient string,
+  p90 float,
+  p95 float,
+  region string
+)
+PARTITIONED BY (d date)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+WITH SERDEPROPERTIES (
+  'serialization.format' = '1'
+)
+LOCATION 's3://ec2-network-benchmark2-global-s3bucket-1ul0glc1xwy4l/v2-cache/';
+
+
+# Load partiations from S3
+
+MSCK REPAIR TABLE cachenetworkbenchmark;
+
+# results in mbit/s
+# Takes Bytes per minute to gbit/s
+SELECT
+  instancetype,
+  dataSize,
+  (avg(networkbytesout.p90)/60/1024/1024*8) AS mbps_p90,
+  avg(cpuutilization.p90) AS cpuutilization_90,
+  avg(enginecpuutilization.p90) AS enginecpuutilization_90,
+  count(distinct benchmarkId) as test_passes
+FROM cachenetworkbenchmark
+WHERE d >= from_iso8601_date('2018-04-01')
+GROUP BY region, instancetype, dataSize
+ORDER BY region, instancetype;

--- a/athena-cache.sql
+++ b/athena-cache.sql
@@ -7,11 +7,27 @@ DROP TABLE IF EXISTS cachenetworkbenchmark;
 
 CREATE EXTERNAL TABLE IF NOT EXISTS cachenetworkbenchmark (
   benchmarkId string,
+  CPUUtilization struct<p50:float,
+                   p70:float,
+                   p90:float,
+                   p95:float,
+                   p99:float
+                  >,
   dataSize int,
+  EngineCPUUtilization struct<p50:float,
+                   p70:float,
+                   p90:float,
+                   p95:float,
+                   p99:float
+                  >,
   instanceType string,
   instanceTypeClient string,
-  p90 float,
-  p95 float,
+  NetworkBytesOut struct<p50:float,
+                   p70:float,
+                   p90:float,
+                   p95:float,
+                   p99:float
+                  >,
   region string
 )
 PARTITIONED BY (d date)

--- a/benchmark-cache.inc.sh
+++ b/benchmark-cache.inc.sh
@@ -1,0 +1,70 @@
+#!/bin/bash -x
+
+INSTANCE_TYPE_CLIENT="c5.18xlarge"
+SPOT_PRICE_CLIENT="3.456"
+STACK_PREFIX=ec2-network-benchmark-
+BASIC_TEST_DURATION=300
+
+# $1 = redis instance type
+# $2 = number of client instances
+# $3 = optional test duration
+function create {
+  local instance_count=${2:-1}
+  local test_duration=${3:-${BASIC_TEST_DURATION}}
+
+  aws cloudformation create-stack \
+      --stack-name ${STACK_PREFIX}${1//./-} \
+      --parameters \
+        ParameterKey=BenchmarkId,ParameterValue=$(uuidgen) \
+        ParameterKey=InstanceCountClient,ParameterValue=$instance_count \
+        ParameterKey=InstanceTypeClient,ParameterValue=$INSTANCE_TYPE_CLIENT \
+        ParameterKey=ParentGlobalStack,ParameterValue=${STACK_PREFIX}global \
+        ParameterKey=ParentVPCStack,ParameterValue=${STACK_PREFIX}vpc \
+        ParameterKey=RedisInstanceType,ParameterValue=$1 \
+        ParameterKey=SpotPriceClient,ParameterValue=$SPOT_PRICE_CLIENT \
+        ParameterKey=TestDuration,ParameterValue=$test_duration \
+      --template-body file://benchmark-elasticache-redis.yaml
+}
+
+# $1 = client instance type
+function wait_create_complete {
+  aws cloudformation wait stack-create-complete --stack-name ${STACK_PREFIX}${1//./-}
+}
+
+# $1 = client instance type
+function delete {
+  aws cloudformation delete-stack --stack-name ${STACK_PREFIX}${1//./-}
+}
+
+# $1 = client instance type
+function wait_delete_complete {
+  aws cloudformation wait stack-delete-complete --stack-name ${STACK_PREFIX}${1//./-}
+}
+
+# $1 = benchmark function to call with an INSTANCE_BENCHMARKS specification
+# $@ = INSTANCE_BENCHMARKS specification
+function loop_through_benchmarks {
+    local loop_call=$1
+    shift
+    local loop_spec=( $@ )
+    local call_args=
+    for loop_arguments in ${loop_spec[@]}
+    do
+        call_args=$(tr ':' ' ' <<<${loop_arguments})
+        $loop_call $call_args
+    done
+}
+
+# $@ = INSTANCE_BENCHMARKS specification
+function execute_test_plan {
+    for call_command in \
+        create \
+        wait_create_complete \
+        delete \
+        wait_delete_complete
+    do
+        loop_through_benchmarks \
+            $call_command \
+            $@
+    done
+}

--- a/benchmark-cache.m3.sh
+++ b/benchmark-cache.m3.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+. benchmark-cache.inc.sh
+
+# Format
+# <redis instance type>[:<client instance count>[:<test duration seconds]]
+INSTANCE_BENCHMARKS=(
+    cache.m3.medium
+    cache.m3.large
+    cache.m3.xlarge
+    cache.m3.2xlarge
+)
+
+execute_test_plan ${INSTANCE_BENCHMARKS[@]}

--- a/benchmark-cache.m4.sh
+++ b/benchmark-cache.m4.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+
+. benchmark-cache.inc.sh
+
+# Format
+# <redis instance type>[:<client instance count>[:<test duration seconds]]
+INSTANCE_BENCHMARKS=(
+    cache.m4.large
+    cache.m4.xlarge
+    cache.m4.2xlarge
+    cache.m4.4xlarge
+    cache.m4.10xlarge
+)
+
+execute_test_plan ${INSTANCE_BENCHMARKS[@]}

--- a/benchmark-cache.r3.sh
+++ b/benchmark-cache.r3.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+
+. benchmark-cache.inc.sh
+
+# Format
+# <redis instance type>[:<client instance count>[:<test duration seconds]]
+INSTANCE_BENCHMARKS=(
+    cache.r3.large
+    cache.r3.xlarge
+    cache.r3.2xlarge
+    cache.r3.4xlarge
+    cache.r3.8xlarge
+)
+
+execute_test_plan ${INSTANCE_BENCHMARKS[@]}

--- a/benchmark-cache.r4.sh
+++ b/benchmark-cache.r4.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -x
+
+. benchmark-cache.inc.sh
+
+# Format
+# <redis instance type>[:<client instance count>[:<test duration seconds]]
+INSTANCE_BENCHMARKS=(
+    cache.r4.large
+    cache.r4.xlarge
+    cache.r4.2xlarge
+    cache.r4.4xlarge
+    cache.r4.8xlarge
+    cache.r4.16xlarge
+)
+
+execute_test_plan ${INSTANCE_BENCHMARKS[@]}

--- a/benchmark-cache.t2.sh
+++ b/benchmark-cache.t2.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -x
+
+. benchmark-cache.inc.sh
+
+# Format
+# <redis instance type>[:<client instance count>[:<test duration seconds]]
+INSTANCE_BENCHMARKS=(
+    cache.t2.micro
+    cache.t2.small
+    cache.t2.medium
+)
+
+execute_test_plan ${INSTANCE_BENCHMARKS[@]}

--- a/benchmark-elasticache-redis.yaml
+++ b/benchmark-elasticache-redis.yaml
@@ -23,10 +23,20 @@ Metadata:
       Parameters:
       - InstanceSubnet
 Parameters:
+  BenchmarkId:
+    Description: |
+      Unique identifier for an execution. Primarily used when InstanceCountClient is >1
+    Default: ''
+    Type: String
   Benchmarks:
     Description: CloudWatch extended statistics to measure
     Default: p50,p70,p90,p95,p99
     Type: CommaDelimitedList
+  InstanceCountClient:
+    Description: Number of client instances to run
+    Default: 1
+    MinValue: 1
+    Type: Number
   InstanceSubnet:
     Description: |
       Subnet to explicitly place ElastiCache & test instance into (overrides ParentVPCStack subnet import)
@@ -226,7 +236,7 @@ Resources:
               --region ${AWS::Region} \
               --start-time $(date --iso-8601=seconds -d "-$elapsedTime seconds") \
               | jq -cr '.Datapoints[0].ExtendedStatistics' \
-              | jq -cr '. + {benchmarkId: "${BenchmarkId}"' \
+              | jq -cr '. + {benchmarkId: "${BenchmarkId}"}' \
               | jq -cr '. + {dataSize: ${RedisDataSize}}' \
               | jq -cr '. + {instanceCount: ${InstanceCountClient}}' \
               | jq -cr '. + {instanceType: "${RedisInstanceType}"}' \
@@ -248,9 +258,9 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       LaunchConfigurationName: !Ref ClientMachineLaunchConfig
-      MinSize: 1
-      MaxSize: 1
-      DesiredCapacity: 1
+      MinSize: !Ref InstanceCountClient
+      MaxSize: !Ref InstanceCountClient
+      DesiredCapacity: !Ref InstanceCountClient
       VPCZoneIdentifier:
         - !If
           - HasInstanceSubnet
@@ -262,7 +272,7 @@ Resources:
           PropagateAtLaunch: true
     CreationPolicy:
       ResourceSignal:
-        Count: 1
+        Count: !Ref InstanceCountClient
         Timeout: PT75M
 
 Outputs:

--- a/benchmark-elasticache-redis.yaml
+++ b/benchmark-elasticache-redis.yaml
@@ -225,17 +225,30 @@ Resources:
               exit 1
             fi
 
-            # Determine what the bandwidth was like for this period
-            aws cloudwatch get-metric-statistics \
-              --dimensions Name=CacheClusterId,Value=${ElastiCacheCluster} \
-              --end-time $(date --iso-8601=seconds) \
-              --extended-statistics ${BenchmarksList} \
-              --metric-name NetworkBytesOut \
-              --namespace AWS/ElastiCache \
-              --period $(($elapsedTime-($elapsedTime%60))) \
-              --region ${AWS::Region} \
-              --start-time $(date --iso-8601=seconds -d "-$elapsedTime seconds") \
-              | jq -cr '.Datapoints[0].ExtendedStatistics' \
+            # Collect metrics
+            for metric_name in \
+                NetworkBytesOut \
+                CPUUtilization \
+                EngineCPUUtilization
+            do
+              aws cloudwatch get-metric-statistics \
+                --dimensions Name=CacheClusterId,Value=${ElastiCacheCluster} \
+                --end-time $(date --iso-8601=seconds) \
+                --extended-statistics ${BenchmarksList} \
+                --metric-name $metric_name \
+                --namespace AWS/ElastiCache \
+                --period $(($elapsedTime-($elapsedTime%60))) \
+                --region ${AWS::Region} \
+                --start-time $(date --iso-8601=seconds -d "-$elapsedTime seconds") \
+                | jq -cr '.Datapoints[0].ExtendedStatistics' \
+                | jq -crs "{ $metric_name : .[0] }" \
+                >/tmp/$metric_name.json
+              done
+
+              # Join all metrics data, add benchmarking parameters, gzip, and
+              # ship to S3
+              cat /tmp/*.json \
+              | jq -crs add \
               | jq -cr '. + {benchmarkId: "${BenchmarkId}"}' \
               | jq -cr '. + {dataSize: ${RedisDataSize}}' \
               | jq -cr '. + {instanceCount: ${InstanceCountClient}}' \

--- a/benchmark-elasticache-redis.yaml
+++ b/benchmark-elasticache-redis.yaml
@@ -67,11 +67,10 @@ Parameters:
     Description: (optional) explicit Redis engine version
     Default: ''
     Type: String
-  RedisDataSize:
-    Description: Size (in bytes) to feed redis-benchmark -d
-    Default: 1024
-    MinValue: 100
-    Type: Number
+  RedisDataSizes:
+    Description: Sizes (in bytes) to feed redis-benchmark -d
+    Default: 1000,10000,100000
+    Type: CommaDelimitedList
   RedisInstanceType:
     Description: The instance type for the Redis instance.
     Type: String
@@ -196,74 +195,81 @@ Resources:
               jq \
               redis-benchmark
 
-            # Set some arbitrary keys
-            redis-benchmark \
-              -h ${ElastiCacheCluster.RedisEndpoint.Address} \
-              -p ${ElastiCacheCluster.RedisEndpoint.Port} \
-              -t set \
-              -d ${RedisDataSize} \
-              -q
+            [ -n "${DataSizes}" ] \
+              && echo "Testing sizes: ${DataSizes}"
 
-            # Execute the test for the specified time
-            startTime=$(date +%s)
-            set +e
-            timeout ${TestDuration} \
+            for data_size in ${DataSizes}
+            do
+              # Set some arbitrary keys
               redis-benchmark \
                 -h ${ElastiCacheCluster.RedisEndpoint.Address} \
                 -p ${ElastiCacheCluster.RedisEndpoint.Port} \
-                -t get \
-                -d ${RedisDataSize} \
-                -n 100000000 \
+                -t set \
+                -d $data_size \
                 -q
-            set -e
-            timeNow=$(date +%s)
-            elapsedTime=$(($timeNow-$startTime))
 
-            if [[ $elapsedTime -eq 0 ]]
-            then
-              echo "Failed to run redis-benchmark"
-              exit 1
-            fi
+              # Execute the test for the specified time
+              startTime=$(date +%s)
+              set +e
+              timeout ${TestDuration} \
+                redis-benchmark \
+                  -h ${ElastiCacheCluster.RedisEndpoint.Address} \
+                  -p ${ElastiCacheCluster.RedisEndpoint.Port} \
+                  -t get \
+                  -d $data_size \
+                  -n 100000000 \
+                  -q
+              set -e
+              timeNow=$(date +%s)
+              elapsedTime=$(($timeNow-$startTime))
 
-            # Collect metrics
-            for metric_name in \
-                NetworkBytesOut \
-                CPUUtilization \
-                EngineCPUUtilization
-            do
-              aws cloudwatch get-metric-statistics \
-                --dimensions Name=CacheClusterId,Value=${ElastiCacheCluster} \
-                --end-time $(date --iso-8601=seconds) \
-                --extended-statistics ${BenchmarksList} \
-                --metric-name $metric_name \
-                --namespace AWS/ElastiCache \
-                --period $(($elapsedTime-($elapsedTime%60))) \
-                --region ${AWS::Region} \
-                --start-time $(date --iso-8601=seconds -d "-$elapsedTime seconds") \
-                | jq -cr '.Datapoints[0].ExtendedStatistics' \
-                | jq -crs "{ $metric_name : .[0] }" \
-                >/tmp/$metric_name.json
-              done
+              if [[ $elapsedTime -eq 0 ]]
+              then
+                echo "Failed to run redis-benchmark"
+                exit 1
+              fi
 
-              # Join all metrics data, add benchmarking parameters, gzip, and
-              # ship to S3
-              cat /tmp/*.json \
-              | jq -crs add \
-              | jq -cr '. + {benchmarkId: "${BenchmarkId}"}' \
-              | jq -cr '. + {dataSize: ${RedisDataSize}}' \
-              | jq -cr '. + {instanceCount: ${InstanceCountClient}}' \
-              | jq -cr '. + {instanceType: "${RedisInstanceType}"}' \
-              | jq -cr '. + {instanceTypeClient: "${InstanceTypeClient}"}' \
-              | jq -cr '. + {region: "${AWS::Region}"}' \
-              | jq -cr ". + {stamp: $timeNow}" \
-              | jq -cr '. + {testDuration: ${TestDuration}}' \
-              | jq -cr ". + {testElapsed: $elapsedTime}" \
-              | gzip \
-              | aws s3 cp \
-                - \
-                "s3://${DestinationBucket}/v2-cache/d=$(date +%Y-%m-%d)/${RedisInstanceType}-$(date +%s).json.gz"
+              # Collect metrics
+              for metric_name in \
+                  NetworkBytesOut \
+                  CPUUtilization \
+                  EngineCPUUtilization
+              do
+                aws cloudwatch get-metric-statistics \
+                  --dimensions Name=CacheClusterId,Value=${ElastiCacheCluster} \
+                  --end-time $(date --iso-8601=seconds) \
+                  --extended-statistics ${BenchmarksList} \
+                  --metric-name $metric_name \
+                  --namespace AWS/ElastiCache \
+                  --period $(($elapsedTime-($elapsedTime%60))) \
+                  --region ${AWS::Region} \
+                  --start-time $(date --iso-8601=seconds -d "-$elapsedTime seconds") \
+                  | jq -cr '.Datapoints[0].ExtendedStatistics' \
+                  | jq -crs "{ $metric_name : .[0] }" \
+                  >/tmp/$metric_name.json
+                done
+
+                # Join all metrics data, add benchmarking parameters, gzip, and
+                # ship to S3
+                cat /tmp/*.json \
+                | jq -crs add \
+                | jq -cr '. + {benchmarkId: "${BenchmarkId}"}' \
+                | jq -cr ". + {dataSize: $data_size}" \
+                | jq -cr '. + {instanceCount: ${InstanceCountClient}}' \
+                | jq -cr '. + {instanceType: "${RedisInstanceType}"}' \
+                | jq -cr '. + {instanceTypeClient: "${InstanceTypeClient}"}' \
+                | jq -cr '. + {region: "${AWS::Region}"}' \
+                | jq -cr ". + {stamp: $timeNow}" \
+                | jq -cr '. + {testDuration: ${TestDuration}}' \
+                | jq -cr ". + {testElapsed: $elapsedTime}" \
+                | gzip \
+                | aws s3 cp \
+                  - \
+                  "s3://${DestinationBucket}/v2-cache/d=$(date +%Y-%m-%d)/${RedisInstanceType}-$(date +%s).json.gz"
+            done
           -
             BenchmarksList: !Join [' ', !Ref Benchmarks]
+            DataSizes: !Join [' ', !Ref RedisDataSizes]
             DestinationBucket:
               Fn::ImportValue: !Sub ${ParentGlobalStack}-S3BucketName
 

--- a/benchmark-elasticache-redis.yaml
+++ b/benchmark-elasticache-redis.yaml
@@ -1,0 +1,273 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: 'EC2 Network Benchmark: elasticache (redis)'
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label: {default: Parent Stacks}
+      Parameters:
+      - ParentVPCStack
+      - ParentGlobalStack
+    - Label: {default: Benchmark Parameters}
+      Parameters:
+      - BenchmarkId
+      - Benchmarks
+      - InstanceCountClient
+      - InstanceTypeClient
+      - RedisCustomParameterGroup
+      - RedisCustomVersion
+      - RedisDataSize
+      - TestDuration
+    - Label: {default: VPC Settings}
+      Parameters:
+      - InstanceSubnet
+Parameters:
+  Benchmarks:
+    Description: CloudWatch extended statistics to measure
+    Default: p50,p70,p90,p95,p99
+    Type: CommaDelimitedList
+  InstanceSubnet:
+    Description: |
+      Subnet to explicitly place ElastiCache & test instance into (overrides ParentVPCStack subnet import)
+    Default: ''
+    Type: String
+  InstanceTypeClient:
+    Default: t2.micro
+    Description: The instance type for the client EC2 instance.
+    Type: String
+  KeyName:
+    AllowedPattern: '^[a-zA-Z0-9_-]*'
+    ConstraintDescription: can contain only alphanumeric characters, spaces, dashes, & underscores
+    Default: ''
+    Description: (optional) EC2 KeyPair Name
+    Type: String
+  ParentGlobalStack:
+    Description: Stack name of parent global stack based on global.yaml template.
+    Type: String
+  ParentVPCStack:
+    Description: Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.
+    Default: ''
+    Type: String
+  RedisCustomParameterGroup:
+    Description: (optional) customer Parameter group
+    Default: ''
+    Type: String
+  RedisCustomVersion:
+    Description: (optional) explicit Redis engine version
+    Default: ''
+    Type: String
+  RedisDataSize:
+    Description: Size (in bytes) to feed redis-benchmark -d
+    Default: 1024
+    MinValue: 100
+    Type: Number
+  RedisInstanceType:
+    Description: The instance type for the Redis instance.
+    Type: String
+    Default: cache.t2.micro
+  SpotPriceClient:
+    Default: 0
+    Description: The spot price for the EC2 instance.
+    Type: Number
+  TestDuration:
+    Description: Number of seconds to run the test for, should always be a multiple of 60
+    Default: 300
+    MinValue: 60
+    Type: Number
+
+Mappings:
+  RegionMap:
+    'ap-south-1':
+      AMI: 'ami-531a4c3c'
+    'eu-west-3':
+      AMI: 'ami-8ee056f3'
+    'eu-west-2':
+      AMI: 'ami-403e2524'
+    'eu-west-1':
+      AMI: 'ami-d834aba1'
+    'ap-northeast-2':
+      AMI: 'ami-863090e8'
+    'ap-northeast-1':
+      AMI: 'ami-ceafcba8'
+    'sa-east-1':
+      AMI: 'ami-84175ae8'
+    'ca-central-1':
+      AMI: 'ami-a954d1cd'
+    'ap-southeast-1':
+      AMI: 'ami-68097514'
+    'ap-southeast-2':
+      AMI: 'ami-942dd1f6'
+    'eu-central-1':
+      AMI: 'ami-5652ce39'
+    'us-east-1':
+      AMI: 'ami-97785bed'
+    'us-east-2':
+      AMI: 'ami-f63b1193'
+    'us-west-1':
+      AMI: 'ami-824c4ee2'
+    'us-west-2':
+      AMI: 'ami-f2d3638a'
+
+Conditions:
+  HasInstanceSubnet: !Not [!Equals [!Ref InstanceSubnet, '']]
+  HasKeyName: !Not [!Equals [!Ref KeyName, '']]
+  HasSpotPriceClient: !Not [!Equals [!Ref SpotPriceClient, 0]]
+  HasRedisCustomParameterGroup: !Not [!Equals [!Ref RedisCustomParameterGroup, '']]
+  HasRedisCustomVersion: !Not [!Equals [!Ref RedisCustomVersion, '']]
+
+Resources:
+  ElastiCacheSubnetGroup:
+    Type: AWS::ElastiCache::SubnetGroup
+    Properties:
+      Description: ElastiCache Network Benchmark Group
+      SubnetIds:
+        - !If
+          - HasInstanceSubnet
+          - !Ref InstanceSubnet
+          - Fn::ImportValue: !Sub ${ParentVPCStack}-SubnetAPublic
+
+  ElastiCacheCluster:
+    Type: AWS::ElastiCache::CacheCluster
+    DependsOn: ElastiCacheSubnetGroup
+    Properties:
+      CacheNodeType: !Ref RedisInstanceType
+      CacheParameterGroupName: !If
+        - HasRedisCustomParameterGroup
+        - !Ref RedisCustomParameterGroup
+        - !Ref 'AWS::NoValue'
+      CacheSubnetGroupName: !Ref ElastiCacheSubnetGroup
+      Engine: redis
+      EngineVersion: !If
+        - HasRedisCustomVersion
+        - !Ref RedisCustomVersion
+        - !Ref 'AWS::NoValue'
+      NumCacheNodes: 1
+      VpcSecurityGroupIds:
+        - Fn::ImportValue: !Sub ${ParentGlobalStack}-SecurityGroupId
+
+  ClientMachineLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      IamInstanceProfile:
+        Fn::ImportValue: !Sub ${ParentGlobalStack}-IAMInstanceProfileName
+      ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMI]
+      InstanceMonitoring: true
+      InstanceType: !Ref InstanceTypeClient
+      KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+      SecurityGroups:
+        - Fn::ImportValue: !Sub ${ParentGlobalStack}-SecurityGroupId
+      SpotPrice: !If [HasSpotPriceClient, !Ref SpotPriceClient, !Ref 'AWS::NoValue']
+      UserData: 
+        Fn::Base64: !Sub
+          - |
+            #!/bin/bash
+            set -exo pipefail
+
+            cleanup ()
+            {
+              /opt/aws/bin/cfn-signal \
+                -e $? \
+                --resource ClientMachineAutoScalingGroup \
+                --stack ${AWS::StackName} \
+                --region ${AWS::Region}
+            }
+            trap cleanup EXIT
+
+            # Enable EPEL
+            yum-config-manager --enable epel
+            yum clean all
+
+            # Install required utilities
+            yum -y install \
+              jq \
+              redis
+            which \
+              jq \
+              redis-benchmark
+
+            # Set some arbitrary keys
+            redis-benchmark \
+              -h ${ElastiCacheCluster.RedisEndpoint.Address} \
+              -p ${ElastiCacheCluster.RedisEndpoint.Port} \
+              -t set \
+              -d ${RedisDataSize} \
+              -q
+
+            # Execute the test for the specified time
+            startTime=$(date +%s)
+            set +e
+            timeout ${TestDuration} \
+              redis-benchmark \
+                -h ${ElastiCacheCluster.RedisEndpoint.Address} \
+                -p ${ElastiCacheCluster.RedisEndpoint.Port} \
+                -t get \
+                -d ${RedisDataSize} \
+                -n 100000000 \
+                -q
+            set -e
+            timeNow=$(date +%s)
+            elapsedTime=$(($timeNow-$startTime))
+
+            if [[ $elapsedTime -eq 0 ]]
+            then
+              echo "Failed to run redis-benchmark"
+              exit 1
+            fi
+
+            # Determine what the bandwidth was like for this period
+            aws cloudwatch get-metric-statistics \
+              --dimensions Name=CacheClusterId,Value=${ElastiCacheCluster} \
+              --end-time $(date --iso-8601=seconds) \
+              --extended-statistics ${BenchmarksList} \
+              --metric-name NetworkBytesOut \
+              --namespace AWS/ElastiCache \
+              --period $(($elapsedTime-($elapsedTime%60))) \
+              --region ${AWS::Region} \
+              --start-time $(date --iso-8601=seconds -d "-$elapsedTime seconds") \
+              | jq -cr '.Datapoints[0].ExtendedStatistics' \
+              | jq -cr '. + {benchmarkId: "${BenchmarkId}"' \
+              | jq -cr '. + {dataSize: ${RedisDataSize}}' \
+              | jq -cr '. + {instanceCount: ${InstanceCountClient}}' \
+              | jq -cr '. + {instanceType: "${RedisInstanceType}"}' \
+              | jq -cr '. + {instanceTypeClient: "${InstanceTypeClient}"}' \
+              | jq -cr '. + {region: "${AWS::Region}"}' \
+              | jq -cr ". + {stamp: $timeNow}" \
+              | jq -cr '. + {testDuration: ${TestDuration}}' \
+              | jq -cr ". + {testElapsed: $elapsedTime}" \
+              | gzip \
+              | aws s3 cp \
+                - \
+                "s3://${DestinationBucket}/v2-cache/d=$(date +%Y-%m-%d)/${RedisInstanceType}-$(date +%s).json.gz"
+          -
+            BenchmarksList: !Join [' ', !Ref Benchmarks]
+            DestinationBucket:
+              Fn::ImportValue: !Sub ${ParentGlobalStack}-S3BucketName
+
+  ClientMachineAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      LaunchConfigurationName: !Ref ClientMachineLaunchConfig
+      MinSize: 1
+      MaxSize: 1
+      DesiredCapacity: 1
+      VPCZoneIdentifier:
+        - !If
+          - HasInstanceSubnet
+          - !Ref InstanceSubnet
+          - Fn::ImportValue: !Sub ${ParentVPCStack}-SubnetAPublic
+      Tags:
+        - Key: Name
+          Value: EC2 Network Benchmark Client
+          PropagateAtLaunch: true
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT75M
+
+Outputs:
+  StackName:
+    Description: Stack name
+    Value: !Sub ${AWS::StackName}
+
+# vim: ft=yaml sw=2 ts=2

--- a/global-wrapper.yaml
+++ b/global-wrapper.yaml
@@ -18,7 +18,7 @@ Resources:
       GroupDescription: !Sub '${AWS::StackName}-client'
       VpcId:
         'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
-  SecurityGroupIngress:
+  SecurityGroupIngressIperf:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
       GroupId: !Sub '${SecurityGroup.GroupId}'
@@ -26,9 +26,17 @@ Resources:
       FromPort: '5201'
       ToPort: '5201'
       SourceSecurityGroupId: !Sub '${SecurityGroup.GroupId}'
+  SecurityGroupIngressRedis:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      GroupId: !Sub '${SecurityGroup.GroupId}'
+      IpProtocol: tcp
+      FromPort: '6379'
+      ToPort: '6379'
+      SourceSecurityGroupId: !Sub '${SecurityGroup.GroupId}'
 Outputs:
   SecurityGroupId:
-    Description: 'The security group id allowing traffic for ipref3.'
+    Description: 'The security group id allowing traffic for ipref3 & redis'
     Value: !Sub '${SecurityGroup.GroupId}'
     Export:
       Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/global-wrapper.yaml
+++ b/global-wrapper.yaml
@@ -4,6 +4,7 @@ Description: 'EC2 Network Benchmark: global (wrapper)'
 Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
+    Default: ''
     Type: String
   S3BucketName:
     Description: 'A wrapper for the S3BucketName'
@@ -11,6 +12,12 @@ Parameters:
   IAMInstanceProfileName:
     Description: 'A wrapper for the IAMInstanceProfileName'
     Type: String
+  VpcId:
+    Description: 'Explicit VPC Id (overrides ParentVPCStack import)'
+    Default: ''
+    Type: String
+Conditions:
+  HasVpcId: !Not [!Equals [!Ref VpcId, '']]
 Resources:
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/global.yaml
+++ b/global.yaml
@@ -8,10 +8,21 @@ Metadata:
         default: 'Parent Stacks'
       Parameters:
       - ParentVPCStack
+    - Label:
+        default: 'VPC Settings'
+      Parameters:
+      - VpcId
 Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
+    Default: ''
     Type: String
+  VpcId:
+    Description: 'Explicit VPC Id (overrides ParentVPCStack import)'
+    Default: ''
+    Type: String
+Conditions:
+  HasVpcId: !Not [!Equals [!Ref VpcId, '']]
 Resources:
   S3Bucket:
     Type: 'AWS::S3::Bucket'
@@ -20,8 +31,10 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: !Sub '${AWS::StackName}-client'
-      VpcId:
-        'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
+      VpcId: !If
+        - HasVpcId
+        - !Ref VpcId
+        - 'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
   SecurityGroupIngressIperf:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:

--- a/global.yaml
+++ b/global.yaml
@@ -70,6 +70,13 @@ Resources:
             - 'autoscaling:DescribeAutoScalingGroups'
             - 'ec2:DescribeInstances'
             Resource: '*'
+      - PolicyName: cloudwatch
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action: 'cloudwatch:getMetricStatistics'
+            Resource: '*'
 Outputs:
   StackName:
     Description: 'Stack name'

--- a/global.yaml
+++ b/global.yaml
@@ -22,13 +22,21 @@ Resources:
       GroupDescription: !Sub '${AWS::StackName}-client'
       VpcId:
         'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
-  SecurityGroupIngress:
+  SecurityGroupIngressIperf:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
       GroupId: !Sub '${SecurityGroup.GroupId}'
       IpProtocol: tcp
       FromPort: '5201'
       ToPort: '5201'
+      SourceSecurityGroupId: !Sub '${SecurityGroup.GroupId}'
+  SecurityGroupIngressRedis:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      GroupId: !Sub '${SecurityGroup.GroupId}'
+      IpProtocol: tcp
+      FromPort: '6379'
+      ToPort: '6379'
       SourceSecurityGroupId: !Sub '${SecurityGroup.GroupId}'
   IAMInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
@@ -67,7 +75,7 @@ Outputs:
     Description: 'Stack name'
     Value: !Sub '${AWS::StackName}'
   SecurityGroupId:
-    Description: 'The security group id allowing traffic for ipref3.'
+    Description: 'The security group id allowing traffic for ipref3 & redis.'
     Value: !Sub '${SecurityGroup.GroupId}'
     Export:
       Name: !Sub '${AWS::StackName}-SecurityGroupId'


### PR DESCRIPTION
This also adds some optional parameters to the existing tests to make it easier on someone to run them without having a separate VPC stack that has exported values.