### PR TITLE
Support for A1 instance types

### DIFF
--- a/benchmark-a1.sh
+++ b/benchmark-a1.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -x
+
+INSTANCE_TYPE_SERVER="c5.18xlarge"
+SPOT_PRICE_SERVER="3.456"
+
+# $1 = client instance type
+function create {
+  aws cloudformation create-stack --stack-name ec2-network-benchmark-${1//./-} --parameters ParameterKey=ParentVPCStack,ParameterValue=vpc-2azs ParameterKey=ParentGlobalStack,ParameterValue=benchmark-global ParameterKey=InstanceTypeClient,ParameterValue=$1 ParameterKey=InstanceTypeServer,ParameterValue=$INSTANCE_TYPE_SERVER ParameterKey=SpotPriceServer,ParameterValue=$SPOT_PRICE_SERVER --template-body file://benchmark.yaml
+}
+
+# $1 = client instance type
+function wait_create_complete {
+  aws cloudformation wait stack-create-complete --stack-name ec2-network-benchmark-${1//./-}
+}
+
+# $1 = client instance type
+function delete {
+  aws cloudformation delete-stack --stack-name ec2-network-benchmark-${1//./-}
+}
+
+# $1 = client instance type
+function wait_delete_complete {
+  aws cloudformation wait stack-delete-complete --stack-name ec2-network-benchmark-${1//./-}
+}
+
+create a1.medium
+create a1.large
+create a1.xlarge
+create a1.2xlarge
+create a1.4xlarge
+
+wait_create_complete a1.medium
+wait_create_complete a1.large
+wait_create_complete a1.xlarge
+wait_create_complete a1.2xlarge
+wait_create_complete a1.4xlarge
+
+delete a1.medium
+delete a1.large
+delete a1.xlarge
+delete a1.2xlarge
+delete a1.4xlarge
+
+wait_delete_complete a1.medium
+wait_delete_complete a1.large
+wait_delete_complete a1.xlarge
+wait_delete_complete a1.2xlarge
+wait_delete_complete a1.4xlarge

--- a/benchmark.yaml
+++ b/benchmark.yaml
@@ -40,39 +40,52 @@ Parameters:
     Default: 0
 Mappings:
   RegionMap:
-    'ap-south-1':
-      AMI: 'ami-531a4c3c'
-    'eu-west-3':
-      AMI: 'ami-8ee056f3'
-    'eu-west-2':
-      AMI: 'ami-403e2524'
-    'eu-west-1':
-      AMI: 'ami-d834aba1'
-    'ap-northeast-2':
-      AMI: 'ami-863090e8'
-    'ap-northeast-1':
-      AMI: 'ami-ceafcba8'
-    'sa-east-1':
-      AMI: 'ami-84175ae8'
-    'ca-central-1':
-      AMI: 'ami-a954d1cd'
-    'ap-southeast-1':
-      AMI: 'ami-68097514'
-    'ap-southeast-2':
-      AMI: 'ami-942dd1f6'
-    'eu-central-1':
-      AMI: 'ami-5652ce39'
-    'us-east-1':
-      AMI: 'ami-97785bed'
-    'us-east-2':
-      AMI: 'ami-f63b1193'
-    'us-west-1':
-      AMI: 'ami-824c4ee2'
-    'us-west-2':
-      AMI: 'ami-f2d3638a'
+    # AMD64:
+    #   CreationDate: '2018-11-14T09:06:55.000Z'
+    #   Name: amzn2-ami-hvm-2.0.20181114-x86_64-gp2
+    #   Owner: amazon
+    # ARM64:
+    #   CreationDate: '2018-11-27T03:53:23.000Z'
+    #   Name: amzn2-ami-hvm-2.0.20181114.1-arm64-gp2
+    #   Owner: amazon
+    ap-northeast-1:
+      AMD64: ami-0a2de1c3b415889d2
+    ap-northeast-2:
+      AMD64: ami-0b4fdb56a00adb616
+    ap-south-1:
+      AMD64: ami-06bcd1131b2f55803
+    ap-southeast-1:
+      AMD64: ami-0b84d2c53ad5250c2
+    ap-southeast-2:
+      AMD64: ami-08589eca6dcc9b39c
+    ca-central-1:
+      AMD64: ami-076b4adb3f90cd384
+    eu-central-1:
+      AMD64: ami-034fffcc6a0063961
+    eu-west-1:
+      AMD64: ami-09693313102a30b2c
+      ARM64: ami-0b97e17c772f052e6
+    eu-west-2:
+      AMD64: ami-0274e11dced17bb5b
+    eu-west-3:
+      AMD64: ami-051707cdba246187b
+    sa-east-1:
+      AMD64: ami-0112d42866980b373
+    us-east-1:
+      AMD64: ami-009d6802948d06e52
+      ARM64: ami-0f8c82faeb08f15da
+    us-east-2:
+      AMD64: ami-02e680c4540db351e
+      ARM64: ami-0998858ab6ad47da8
+    us-west-1:
+      AMD64: ami-011b6930a81cd6aaf
+    us-west-2:
+      AMD64: ami-01bbe152bf19d0289
+      ARM64: ami-0f374ff3bc5bb0929
 Conditions:
   HasSpotPriceClient: !Not [!Equals [!Ref SpotPriceClient, 0]]
   HasSpotPriceServer: !Not [!Equals [!Ref SpotPriceServer, 0]]
+  IsArmInstance: !Equals [ !Select [ 0, !Split ['.',  !Ref InstanceTypeClient] ], 'a1' ]
 Resources:
   ClientMachineLaunchConfig:
     Type: 'AWS::AutoScaling::LaunchConfiguration'
@@ -80,17 +93,22 @@ Resources:
       SpotPrice: !If [HasSpotPriceClient, !Ref SpotPriceClient, !Ref 'AWS::NoValue']
       IamInstanceProfile:
         'Fn::ImportValue': !Sub '${ParentGlobalStack}-IAMInstanceProfileName'
-      ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMI]
+      ImageId:
+        Fn::If:
+          - IsArmInstance
+          - !FindInMap [RegionMap, !Ref 'AWS::Region', ARM64]
+          - !FindInMap [RegionMap, !Ref 'AWS::Region', AMD64]
       InstanceType: !Ref InstanceTypeClient
       SecurityGroups:
       - 'Fn::ImportValue': !Sub '${ParentGlobalStack}-SecurityGroupId'
       InstanceMonitoring: true
-      UserData: 
+      UserData:
         'Fn::Base64': !Join
         - ''
         - - "#!/bin/bash -x \n"
           - "bash -ex << \"TRY\"\n"
-          - "  yum-config-manager --enable epel \n"
+          - "  amazon-linux-extras enable epel \n"
+          - "  yum install -y epel-release \n"
           - "  yum clean all \n"
           - "  yum -y install iperf3 jq \n"
           - "  sleep 60 \n"
@@ -128,7 +146,7 @@ Resources:
       SpotPrice: !If [HasSpotPriceServer, !Ref SpotPriceServer, !Ref 'AWS::NoValue']
       IamInstanceProfile:
         'Fn::ImportValue': !Sub '${ParentGlobalStack}-IAMInstanceProfileName'
-      ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMI]
+      ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMD64]
       InstanceType: !Ref InstanceTypeServer
       SecurityGroups:
       - 'Fn::ImportValue': !Sub '${ParentGlobalStack}-SecurityGroupId'


### PR DESCRIPTION
required changes to benchmark.yaml to support ARM AMIs. Only Amazon Linux 2 provides ARM support so the ClientInstance has been adapted to work with amzn2.

Pretty impressive results from my testing. The a1.medium maxed out its CPU.

  | min | max | avg | stddev | p95 | p90 | p70 | p50 | p30 | p05 | region | instancetype
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 0.496266 | 7.073710 | 0.982033 | 1.6773408450426444 | 7.0353837 | 0.4966589 | 0.49654186 | 0.496475 | 0.4964083 | 0.49630797 | us-east-2 | a1.medium
2 | 0.744224 | 9.614590 | 1.530284 | 2.2690880079166065 | 7.5546713 | 7.4792824 | 0.74482507 | 0.7447232 | 0.7446417 | 0.744441 | us-east-2 | a1.large
3 | 1.243012 | 7.579765 | 2.724897 | 2.6812509404068163 | 7.577725 | 7.550634 | 1.243672 | 1.243497 | 1.243397 | 1.243263 | us-east-2 | a1.xlarge
4 | 2.486438 | 10.039530 | 5.034777 | 3.5753592005289008 | 10.03773 | 10.03772 | 10.03742 | 2.486992 | 2.4868412 | 2.4865558 | us-east-2 | a1.2xlarge
5 | 4.973171 | 10.038970 | 8.421900 | 2.363842101849899 | 10.03888 | 10.03885 | 10.038711 | 10.00869 | 5.0719895 | 4.9735303 | us-east-2 | a1.4xlarge




